### PR TITLE
[Fixed] Do not linger unused pngs in the output dir

### DIFF
--- a/kicad-diff.py
+++ b/kicad-diff.py
@@ -461,6 +461,7 @@ def DiffImages(old_file_hash, new_file_hash, layers_old, layers_new, only_differ
             if inc:
                 files.append(diff_name)
             else:
+                remove(diff_name)
                 skipped = skipped+1
     # Check if we skipped all
     if len(files) == 1 and skipped:


### PR DESCRIPTION
When using `--only_different`, some page PNGs are generated and only then decided to be skipped. To not include them in the resulting PDF, these are not included in the `files` array, but this also means they are never deleted (regardless of whether `--keep_pngs` is passed).

This commit removes these pngs again immediately so they not linger around. This also means that they are not kept with `--keep_pngs`, but that should be ok - only pages that are in the PDF are kept now.